### PR TITLE
Fix typos

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -4,4 +4,4 @@ title: Limitations
 ---
 
 - Object ids need to be 48bit signed integers.
-- Only the first 1024 byes of a string can be used for an prefix where clause
+- Only the first 1024 bytes of a string can be used for an prefix where clause

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -85,7 +85,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/isar/docs/edit/master/',
+          editUrl: 'https://github.com/isar/docs/edit/main/',
           routeBasePath: '/',
         },
         theme: {


### PR DESCRIPTION
I found a bug when I click the edit button and a typo in the limitations page
