### PR TITLE
Install the path_provider package

### DIFF
--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -58,6 +58,8 @@ flutter pub run build_runner build
 
 This opens an Isar instance at a valid location.
 
+#### `getApplicationSupportDirectory()` is part of the `path_provider` library
+
 ```dart
 final dir = await getApplicationSupportDirectory();
 


### PR DESCRIPTION
Shows the user how to get the `getApplicationSupportDirectory` function if they don't have `path_provider` already installed.